### PR TITLE
docs: make obvious where the store come from (#1687)

### DIFF
--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -280,6 +280,10 @@ export function createPlugin (options = {}) {
 You can register a module **after** the store has been created with the `store.registerModule` method:
 
 ``` js
+import Vuex from 'vuex'
+
+const store = new Vuex.Store({ /* options */ })
+
 // register a module `myModule`
 store.registerModule('myModule', {
   // ...


### PR DESCRIPTION
* docs: make obvious where to import store from

As we browse through the modules page, it is unclear where the `store` is imported from.

Since it is a one liner, I thought it would clarify to have the import explicitly here.

Tell me what you think.

* docs: import vuex instead of store

Co-Authored-By: Katashin <ktsn55@gmail.com>

Co-authored-by: Katashin <ktsn55@gmail.com>